### PR TITLE
file/download: fixed hash compare when cache: false

### DIFF
--- a/src/file/download.coffee.md
+++ b/src/file/download.coffee.md
@@ -196,7 +196,7 @@ nikita.download
                 return callback Error "Invalid downloaded checksum, found '#{hash}' instead of '#{source_hash}'" if source_hash isnt hash
                 callback()
           @call (_, callback) ->
-            file.compare_hash null, stageDestination, options.ssh, options.target, algo, (err, match, hash1, hash2) ->
+            file.compare_hash (if options.cache then null else options.ssh), stageDestination, options.ssh, options.target, algo, (err, match, hash1, hash2) ->
               options.log message: "Hash dont match, source is '#{hash1}' and target is '#{hash2}'", level: 'WARN', module: 'nikita/lib/file/download' unless match
               options.log message: "Hash matches as '#{hash1}'", level: 'INFO', module: 'nikita/lib/file/download' if match
               callback err, not match
@@ -234,7 +234,7 @@ nikita.download
         handler: ->
           options.log message: "File Download with ssh (with or without cache)", level: 'DEBUG', module: 'nikita/lib/file/download'
           @call (_, callback) ->
-            file.compare_hash null, options.source, options.ssh, options.target, algo, (err, match, hash1, hash2) ->
+            file.compare_hash (if options.cache then null else options.ssh), options.source, options.ssh, options.target, algo, (err, match, hash1, hash2) ->
               options.log message: "Hash dont match, source is '#{hash1}' and target is '#{hash2}'", level: 'WARN', module: 'nikita/lib/file/download' unless match
               options.log message: "Hash matches as '#{hash1}'", level: 'INFO', module: 'nikita/lib/file/download' if match
               callback err, not match


### PR DESCRIPTION
I needed this fix to be able to use `@file.download` with `cache: false` directly on a remote machine.
`compare_hash `with `ssh1=null` was causing an error as the file did not exist in the distant machine's staging directory.