### PR TITLE
core.execute: fix retry fork bomb

### DIFF
--- a/packages/core/lib/system/execute/index.js
+++ b/packages/core/lib/system/execute/index.js
@@ -167,6 +167,10 @@ module.exports = function({options}, callback) {
   if (options.cmd && options.trap) {
     options.cmd = `set -e\n${options.cmd}`;
   }
+  if (options.cmd_original) {
+    // Restore original command if any
+    options.cmd = options.cmd_original;
+  }
   options.cmd_original = `${options.cmd}`;
   if (options.dirty == null) {
     options.dirty = false;

--- a/packages/core/src/system/execute/index.coffee.md
+++ b/packages/core/src/system/execute/index.coffee.md
@@ -133,6 +133,8 @@ nikita.system.execute({
       options.bash = 'bash' if options.bash is true
       options.arch_chroot = 'arch-chroot' if options.arch_chroot is true
       options.cmd = "set -e\n#{options.cmd}" if options.cmd and options.trap
+      # Restore original command if any
+      options.cmd = options.cmd_original if options.cmd_original
       options.cmd_original = "#{options.cmd}"
       options.dirty ?= false
       throw Error "Required Option: the \"cmd\" option is not provided" unless options.cmd?


### PR DESCRIPTION
In `system.execute` the `options.cmd` is changed to execute the temporary script containing the command to execute, but this is kept across retries and launches a bash script that calls itself.

The `options.cmd_original` is used to display the executed command in log and is also kept across retries, by checking its existence we know if we are in a retry and if `options.cmd` no longer holds the real command.