### PR TITLE
engine: fix test

### DIFF
--- a/packages/engine/test/plugins/log.coffee
+++ b/packages/engine/test/plugins/log.coffee
@@ -22,6 +22,7 @@ describe 'plugins.log', ->
           raw_input: false
           raw_output: false
           namespace: []
+          debug: false
           depth: 0
           disabled: false
           relax: false


### PR DESCRIPTION
Since event unregistration commit, metadata `debug` was missing in log test.