### PR TITLE
file: render, engine: update string render templating engine

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -59,6 +59,7 @@
     "ajv": "^6.12.2",
     "ajv-keywords": "^3.4.1",
     "colors": "^1.4.0",
+    "handlebars": "^4.7.6",
     "minimatch": "~3.0.4",
     "mixme": "^0.3.5",
     "pad": "^3.2.0",

--- a/packages/engine/src/utils/string.coffee
+++ b/packages/engine/src/utils/string.coffee
@@ -43,31 +43,16 @@ module.exports =
         "#{time}ms"
     snake_case: (str) ->
       str.replace(/([a-z\d])([A-Z]+)/g, '$1_$2').replace(/[-\s]+/g, '_').toLowerCase()
-    # render: (options) ->
-    #   @log message: "Rendering with #{options.engine}", level: 'DEBUG', module: 'nikita/lib/write'
-    #   try
-    #     switch options.engine
-    #       when 'nunjunks'
-    #         env = new nunjucks.Environment null, autoescape: false
-    #         options.filters ?= {}
-    #         options.filters.isString ?= (obj) -> typeof obj is 'string'
-    #         options.filters.isArray ?= (obj) -> Array.isArray obj
-    #         options.filters.isObject ?= (obj) -> typeof obj is 'object' and not Array.isArray obj
-    #         options.filters.contains ?= (arr, obj) -> if Array.isArray arr then obj in arr else false
-    #         options.filters.isEmpty ?= (obj) ->
-    #           return true if !obj? or obj is ''
-    #           return true if Array.isArray obj and obj.length is 0
-    #           return true if typeof obj is 'object' and Object.keys(obj).length is 0
-    #           return false
-    #         for filter, func of options.filters
-    #           if typeof func is 'function'
-    #             env.addFilter filter, func
-    #           else
-    #             @log message: "Option filter not a function and ignored", level: 'WARN', module: 'nikita/lib/write'
-    #         options.content = env.renderString options.content.toString(), options.context
-    #       else throw Error "Invalid engine: #{options.engine}"
-    #   catch err
-    #     throw (if typeof err is 'string' then Error(err) else err)
+    render: (options) ->
+      # @log message: "Rendering with #{options.engine}", level: 'DEBUG', module: 'nikita/lib/write'
+      try
+        switch options.engine
+          when 'handlebars'
+            template = handlebars.compile options.content.toString()
+            options.content = template options.context
+          else throw Error "Invalid engine: #{options.engine}"
+      catch err
+        throw (if typeof err is 'string' then Error(err) else err)
     replace_partial: (options) ->
       return unless options.write?.length
       @log message: "Replacing sections of the file", level: 'DEBUG', module: 'nikita/lib/misc/string'
@@ -151,3 +136,4 @@ module.exports =
 # nunjucks = require 'nunjucks/src/environment'
 quote = require 'regexp-quote'
 crypto = require 'crypto'
+handlebars = require 'handlebars'

--- a/packages/file/src/index.coffee.md
+++ b/packages/file/src/index.coffee.md
@@ -197,7 +197,7 @@ require('nikita')
           Encoding of the source and target files.
           """
         'engine':
-          type: 'string', default: 'mustache'
+          type: 'string', default: 'handlebars'
           description: """
           Template engine being used.
           """

--- a/packages/file/src/register.coffee
+++ b/packages/file/src/register.coffee
@@ -14,7 +14,7 @@ module.exports =
     # properties:
     #   '': '@nikitajs/file/src/properties'
     #   read: '@nikitajs/file/src/properties/read'
-    # render: '@nikitajs/file/src/render'
+    render: '@nikitajs/file/src/render'
     touch: '@nikitajs/file/src/touch'
     upload: '@nikitajs/file/src/upload'
     # yaml: '@nikitajs/file/src/yaml'

--- a/packages/file/src/render.coffee.md
+++ b/packages/file/src/render.coffee.md
@@ -1,0 +1,99 @@
+
+# `nikita.file.render`
+
+Render a template file. More templating engine could be added on demand. The
+following templating engines are integrated:
+
+* [Handlebars](https://handlebarsjs.com/)
+
+If target is a callback, it will be called with the generated content as
+its first argument.   
+
+## Callback parameters
+
+* `err`   
+  Error object if any.   
+* `status`   
+  Value is true if rendered file was created or modified.   
+
+## Rendering with Nunjucks
+
+```js
+require('nikita')
+.file.render({
+  source: './some/a_template.j2',
+  target: '/tmp/a_file',
+  context: {
+    username: 'a_user'
+  }
+}, function(err, {status}){
+  console.log(err ? err.message : 'File rendered: ' + status);
+});
+```
+
+## On config
+
+    on_action = ({config}) ->
+      # Validate parameters
+      config.encoding ?= 'utf8'
+      throw Error 'Required option: source or content' unless config.source or config.content
+      # Extension
+      if not config.engine and config.source
+        extension = path.extname config.source
+        switch extension
+          when '.hbs' then config.engine = 'handlebars'
+          else throw Error "Invalid Option: extension '#{extension}' is not supported"
+
+## Schema
+
+    schema =
+      type: 'object'
+      properties:
+        'content':
+          $ref: 'module://@nikitajs/file/src/index#/properties/content'
+        'context':
+          $ref: 'module://@nikitajs/file/src/index#/properties/context'
+        'engine':
+          $ref: 'module://@nikitajs/file/src/index#/properties/engine'
+        'gid':
+          $ref: 'module://@nikitajs/engine/src/actions/fs/base/chown#/properties/gid'
+        'mode':
+          $ref: 'module://@nikitajs/engine/src/actions/fs/base/chmod#/properties/mode'
+        'local':
+          $ref: 'module://@nikitajs/file/src/index#/properties/local'
+        'source':
+          $ref: 'module://@nikitajs/file/src/index#/properties/source'
+        'target':
+          $ref: 'module://@nikitajs/file/src/index#/properties/target'
+        'uid':
+          $ref: 'module://@nikitajs/engine/src/actions/fs/base/chown#/properties/uid'
+      required: ['target', 'context']
+
+## Handler
+
+    handler = ({config, log}) ->
+      log message: "Entering file.render", level: 'DEBUG', module: 'nikita/lib/file/render'
+      # Read source
+      if config.source
+        data = await @fs.base.readFile
+          ssh: if config.local then false else config.ssh
+          sudo: if config.local then false else config.sudo
+          target: config.source
+          encoding: config.encoding
+        if data?
+          config.source = undefined
+          config.content = data
+      @file config
+      {}
+
+## Exports
+
+    module.exports =
+      handler: handler
+      hooks:
+        on_action: on_action
+      schema: schema
+
+## Dependencies
+
+    path = require 'path'

--- a/packages/file/test/render.coffee
+++ b/packages/file/test/render.coffee
@@ -1,0 +1,84 @@
+
+nikita = require '@nikitajs/engine/src'
+{tags, ssh, tmpdir} = require './test'
+they = require('ssh2-they').configure ssh...
+
+return unless tags.posix
+
+describe 'file.render', ->
+
+  describe 'error', ->
+
+    they 'when option "source" doesnt exist', ({ssh}) ->
+      nikita
+        ssh: ssh
+        tmpdir: true
+      , ({metadata: {tmpdir}}) ->
+        @file.render
+          source: "#{tmpdir}/oups.hbs"
+          target: "#{tmpdir}/output"
+          context: {}
+        .should.be.rejectedWith message: "NIKITA_FS_CRS_TARGET_ENOENT: fail to read a file because it does not exist, location is \"#{tmpdir}/oups.hbs\"."
+
+    they 'when option "context" is missing', ({ssh}) ->
+      nikita
+        ssh: ssh
+        tmpdir: true
+      , ({metadata: {tmpdir}}) ->
+        @file.render
+          content: 'Hello {{ who }}'
+          target: "#{tmpdir}/output"
+        .should.be.rejectedWith message: 'NIKITA_SCHEMA_VALIDATION_CONFIG: one error was found in the configuration: #/required config should have required property \'context\'.' 
+
+    they 'unsupported source extension', ({ssh}) ->
+      nikita
+        ssh: ssh
+        tmpdir: true
+      , ({metadata: {tmpdir}}) ->
+        @file.render
+          source: 'gohome.et'
+          target: "#{tmpdir}/output"
+          context: {}
+        .should.be.rejectedWith message: "Invalid Option: extension '.et' is not supported" 
+
+  describe 'handlebars', ->
+
+    they 'detect `source`', ({ssh}) ->
+      nikita
+        ssh: ssh
+        tmpdir: true
+      , ({metadata: {tmpdir}}) ->
+        @fs.base.writeFile
+          target: "#{tmpdir}/source.hbs"
+          content: 'Hello {{ who }}'
+          templated: false
+        @file.render
+          source: "#{tmpdir}/source.hbs"
+          target: "#{tmpdir}/target.txt"
+          context: who: 'you'
+          templated: false
+        .should.be.resolvedWith status: true
+        @fs.assert
+          target: "#{tmpdir}/target.txt"
+          content: 'Hello you'
+
+    they 'check autoescaping (disabled)', ({ssh}) ->
+      nikita
+        ssh: ssh
+        tmpdir: true
+      , ({metadata: {tmpdir}}) ->
+        @fs.base.writeFile
+          target: "#{tmpdir}/source.hbs"
+          content: 'Hello "{{ who }}" \'{{ anInt }}\''
+          templated: false
+        @file.render
+          source: "#{tmpdir}/source.hbs"
+          target: "#{tmpdir}/target.txt"
+          context:
+            who: 'you'
+            anInt: 42
+          templated: false
+        .should.be.resolvedWith status: true
+        @fs.assert
+          target: "#{tmpdir}/target.txt"
+          content: 'Hello "you" \'42\''


### PR DESCRIPTION
This PR fixes #158 and migrates `file.render`.