### PR TITLE
utils: fix ini and import tests from core

### DIFF
--- a/packages/file/src/ini.coffee.md
+++ b/packages/file/src/ini.coffee.md
@@ -17,7 +17,7 @@ provided in the `content` option.
 Available values for the `stringify` option are:
 
 * `stringify`
-  Default, implemented by `require('nikita/lib/misc/ini').stringify`
+  Default, implemented by `require('nikita/file/lib/utils/ini').stringify`
 
 The default stringify function accepts:
 
@@ -100,14 +100,15 @@ console.info(`Content was updated: ${status}`)
           typeof: 'function'
           description: """
           User-defined function to parse the content from ini format, default to
-          `require('ini').parse`, see 'misc.ini.parse\_multi\_brackets'.
-          """
+          `require('ini').parse`, see
+          'nikita.file.utils.ini.parse\_multi\_brackets'. """
         'stringify':
           typeof: 'function'
           description: """
           User-defined function to stringify the content to ini format, default
           to `require('ini').stringify`, see
-          'misc.ini.stringify\_brackets\_then_curly' for an example.
+          'nikita.file.utils.ini.stringify\_brackets\_then_curly' for an
+          example.
           """
         'source':
           type: 'string'
@@ -129,7 +130,7 @@ console.info(`Content was updated: ${status}`)
       # log message: "Entering file.ini", level: 'DEBUG', module: 'nikita/lib/file/ini'
       org_props = {}
       default_props = {}
-      parse = config.parse or ini.parse
+      parse = config.parse or utils.ini.parse
       # Original properties
       try
         {data} = await @fs.base.readFile
@@ -158,7 +159,7 @@ console.info(`Content was updated: ${status}`)
         log message: "Clean content", level: 'INFO', module: 'nikita/lib/file/ini'
         utils.object.clean config.content
       log message: "Serialize content", level: 'DEBUG', module: 'nikita/lib/file/ini'
-      stringify = config.stringify or ini.stringify
+      stringify = config.stringify or utils.ini.stringify
       @file
         target: config.target
         content: stringify config.content, config
@@ -177,8 +178,5 @@ console.info(`Content was updated: ${status}`)
 
 ## Dependencies
 
-    utils = require '@nikitajs/engine/lib/utils'
-    ini = require './utils/ini'
+    utils = require './utils'
     {merge} = require 'mixme'
-
-[ini]: https://github.com/isaacs/ini

--- a/packages/file/test/utils/ini/parse.coffee
+++ b/packages/file/test/utils/ini/parse.coffee
@@ -1,10 +1,10 @@
 
-ini = require '../../src/misc/ini'
-{tags} = require '../test'
+{ini} = require '../../../src/utils'
+{tags} = require '../../test'
 
 return unless tags.api
 
-describe 'misc.ini parse', ->
+describe 'utils.ini.parse', ->
 
   it 'parse depth 1', ->
     ini.parse """

--- a/packages/file/test/utils/ini/parse_brackets_then_curly.coffee
+++ b/packages/file/test/utils/ini/parse_brackets_then_curly.coffee
@@ -1,10 +1,10 @@
 
-ini = require '../../src/misc/ini'
-{tags} = require '../test'
+{ini} = require '../../../src/utils'
+{tags} = require '../../test'
 
 return unless tags.api
 
-describe 'misc.ini parse_brackets_then_curly', ->
+describe 'utils.ini.parse_brackets_then_curly', ->
 
   it 'parse braket, no values', ->
     ini.parse_brackets_then_curly """
@@ -71,7 +71,7 @@ describe 'misc.ini parse_brackets_then_curly', ->
             key1112: {}
         key12:
           key121:
-            key1211: 
+            key1211:
               key12111: 'value 12111'
           key122: 'value 122'
       key2:

--- a/packages/file/test/utils/ini/parse_multi_brackets.coffee
+++ b/packages/file/test/utils/ini/parse_multi_brackets.coffee
@@ -1,10 +1,10 @@
 
-ini = require '../../src/misc/ini'
-{tags} = require '../test'
+{ini} = require '../../../src/utils'
+{tags} = require '../../test'
 
 return unless tags.api
 
-describe 'misc.ini parse_multi_brackets', ->
+describe 'utils.ini.parse_multi_brackets', ->
 
   describe 'multi brackets', ->
 

--- a/packages/file/test/utils/ini/parse_multi_brackets_multi_lines.coffee
+++ b/packages/file/test/utils/ini/parse_multi_brackets_multi_lines.coffee
@@ -1,10 +1,10 @@
 
-ini = require '../../src/misc/ini'
-{tags} = require '../test'
+{ini} = require '../../../src/utils'
+{tags} = require '../../test'
 
 return unless tags.api
 
-describe 'misc.ini parse_multi_brackets_multi_lines', ->
+describe 'utils.ini.parse_multi_brackets_multi_lines', ->
 
   it 'parse', ->
     ini.parse_multi_brackets_multi_lines """

--- a/packages/file/test/utils/ini/stringify.coffee
+++ b/packages/file/test/utils/ini/stringify.coffee
@@ -1,10 +1,10 @@
 
-ini = require '../../src/misc/ini'
-{tags} = require '../test'
+{ini} = require '../../../src/utils'
+{tags} = require '../../test'
 
 return unless tags.api
 
-describe 'misc.ini stringify', ->
+describe 'utils.ini.stringify', ->
 
   it 'honors option separator', ->
     ini.stringify

--- a/packages/file/test/utils/ini/stringify_multi_brackets.coffee
+++ b/packages/file/test/utils/ini/stringify_multi_brackets.coffee
@@ -1,10 +1,10 @@
 
-ini = require '../../src/misc/ini'
-{tags} = require '../test'
+{ini} = require '../../../src/utils'
+{tags} = require '../../test'
 
 return unless tags.api
 
-describe 'misc.ini stringify_multi_brackets', ->
+describe 'utils.ini.stringify_multi_brackets', ->
 
   it 'stringify test eol', ->
     res = ini.stringify_multi_brackets

--- a/packages/file/test/utils/ini/stringify_square_then_curly.coffee
+++ b/packages/file/test/utils/ini/stringify_square_then_curly.coffee
@@ -1,10 +1,10 @@
 
-ini = require '../../src/misc/ini'
-{tags} = require '../test'
+{ini} = require '../../../src/utils'
+{tags} = require '../../test'
 
 return unless tags.api
 
-describe 'misc.ini stringify_brackets_then_curly', ->
+describe 'utils.ini.stringify_brackets_then_curly', ->
 
   it 'option eol', ->
     ini.stringify_brackets_then_curly

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -38,6 +38,7 @@
     }
   ],
   "dependencies": {
+    "@nikitajs/file": "^0.9.7-alpha.2",
     "dayjs": "^1.9.4",
     "jsesc": "^2.5.2",
     "mixme": "^0.4.0"

--- a/packages/tools/src/repo.coffee.md
+++ b/packages/tools/src/repo.coffee.md
@@ -151,4 +151,4 @@ console.info(`Repo was updated: ${status}`)
 
 ## Dependencies
 
-    utils = require './utils'
+    utils = require "@nikitajs/file/lib/utils"


### PR DESCRIPTION
There was a issue in `packages/tools/src/repo.coffee.md` on line 113. It is using `ini.parse_multi_brackets`, but when I was moving to consistence `utils` I didn't notice that it is imported from `file.utils`.