### PR TITLE
file: fix ini package version

### DIFF
--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "diff": "^4.0.2",
     "handlebars": "^4.7.6",
+    "ini": "^1.3.8",
     "mixme": "^0.4.0",
     "season": "^6.0.2",
     "xmlbuilder": "^15.1.1",


### PR DESCRIPTION
From the conversation in Keybase
> We've got an issue with the new version of ini package 1.3.7. the last one working is 1.3.6. file/test/ini.coffee not passing, because ini.parse returns [Object: null prototype]{...} instead of just {...}. We can do:
> - we stay at 1.3.6 for some time. there are 2 fresh issues already https://github.com/npm/ini/issues

This error in `ini` package was fixed in 1.3.8. The package was also evolved to 2.0.0, but it is not yet ready, seams it has same problem like in 1.3.7.