### PR TITLE
test(engine): fix actions.wait test

### DIFF
--- a/packages/engine/test/actions/wait.coffee
+++ b/packages/engine/test/actions/wait.coffee
@@ -8,9 +8,11 @@ return unless tags.posix
 describe 'actions.wait', ->
 
   they 'time as main argument', ({ssh}) ->
-    before = Date.now()
+    before = 0
     nikita
       ssh: ssh
+    .call ->
+      before = Date.now()
     .wait 500
     .wait '500'
     .wait 0


### PR DESCRIPTION
Fixes a test because of a delay when initializing nikita action due to j8 optimisation