### PR TITLE
docs: fix website TOC

### DIFF
--- a/docs/website/src/components/shared/Content.js
+++ b/docs/website/src/components/shared/Content.js
@@ -139,7 +139,8 @@ class Content extends Component {
                 <EditIcon />
               </IconButton>
             </Tooltip>
-            {page.tableOfContents.items
+            {page.tableOfContents
+              && page.tableOfContents.items
               && (
               <>
                 <Tooltip

--- a/docs/website/src/components/shared/Toc.js
+++ b/docs/website/src/components/shared/Toc.js
@@ -27,14 +27,14 @@ export default ({
 }) => {
   const renderToc = (level, startLevel, items) => (
     items.map((item) => (
-      <>
+      <React.Fragment key={item.url}>
         {(level >= startLevel) && (
-          <li key={item.url}>
-            <a href={`${item.url}`}>{item.title}</a>
+          <li>
+            <a href={item.url}>{item.title}</a>
           </li>
         )}
         {item.items && renderToc(++level, startLevel, item.items)}
-      </>
+      </React.Fragment>
     ))
   )
   return (


### PR DESCRIPTION
Fixes:
- when `yarn build`, it couldn't generate page 404
- fix key attribute for JSX list of elements