### PR TITLE
docs: fix header links

### DIFF
--- a/docs/website/gatsby-config.js
+++ b/docs/website/gatsby-config.js
@@ -126,6 +126,9 @@ module.exports = {
             },
           },
         ],
+        // Fixes CSS of anchor icon
+        // see https://github.com/gatsbyjs/gatsby/issues/20441 
+        plugins: ['gatsby-remark-autolink-headers']
       }
     },
     {


### PR DESCRIPTION
I made a dirty fix.

The style for autolinks should be applied by default by the plugin. But I couldn't find why the [gatsby-ssr.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js) file implementing these styles is not being called. Probably, it is because of `gatsby-plugin-mdx`.