### PR TITLE
docs: fix website offset to headers

### DIFF
--- a/docs/website/gatsby-config.js
+++ b/docs/website/gatsby-config.js
@@ -130,9 +130,11 @@ module.exports = {
           },
           {
             resolve: 'gatsby-remark-autolink-headers',
-            options: {
-              offsetY: '64', // <600: 48; >600:64
-            },
+            // Option `offsetY` doesn't work with gatsby-plugin-mdx,
+            // see https://github.com/gatsbyjs/gatsby/issues/19859#issuecomment-634061592
+            // options: {
+            //   offsetY: '64', // <600: 48; >600:64
+            // },
           },
           {
             resolve: `gatsby-remark-prismjs`,

--- a/docs/website/src/layout/theme.js
+++ b/docs/website/src/layout/theme.js
@@ -3,6 +3,7 @@ import lightBlue from '@material-ui/core/colors/lightBlue';
 import {styles} from '@material-ui/core/Typography/Typography';
 
 // A custom theme for this app
+const scrollMarginTop = 'calc(74px + 1rem)' // Compensate AppBar height + some margin
 let theme = createMuiTheme({
   props: {
     MuiButtonBase: {
@@ -46,10 +47,12 @@ let theme = createMuiTheme({
     h2: {
       fontSize: '2rem',
       color: '#777777',
+      scrollMarginTop: scrollMarginTop
     },
     h3: {
       fontSize: '1.5rem',
       color: '#777777',
+      scrollMarginTop: scrollMarginTop
     },
   },
 });


### PR DESCRIPTION

Due the issue https://github.com/gatsbyjs/gatsby/issues/19859#issuecomment-634061592, I did different offset setting using CSS.

Another solution would be to duplicate `gatsby-remark-autolink-headers` configuring like on this example - https://github.com/TkDodo/blog/commit/fe0a1c78498c900066873b567eafd80158a73ec8