### PR TITLE
docs: make website headers more visible

### DIFF
--- a/docs/website/src/components/shared/Content.js
+++ b/docs/website/src/components/shared/Content.js
@@ -59,14 +59,14 @@ const useStyles = theme => ({
       ...theme.typography.h2,
       ...theme.typography.gutterBottom,
       fontWeight: 'normal',
-      marginTop: theme.spacing(4),
+      marginTop: theme.spacing(6),
     },
     '& h3': {
       ...theme.typography.root,
       ...theme.typography.h3,
       ...theme.typography.gutterBottom,
       fontWeight: 'normal',
-      marginTop: theme.spacing(3),
+      marginTop: theme.spacing(4),
     },
     '& blockquote': {
       borderLeft: '3px solid #777777',

--- a/docs/website/src/layout/theme.js
+++ b/docs/website/src/layout/theme.js
@@ -42,16 +42,16 @@ let theme = createMuiTheme({
     h1: {
       fontSize: '3rem',
       wordWrap: 'break-word',
-      color: '#777777',
+      color: '#333',
     },
     h2: {
       fontSize: '2rem',
-      color: '#777777',
+      color: '#333',
       scrollMarginTop: scrollMarginTop
     },
     h3: {
       fontSize: '1.5rem',
-      color: '#777777',
+      color: '#333',
       scrollMarginTop: scrollMarginTop
     },
   },


### PR DESCRIPTION
Headers don't contrast well with the content texts. it causes the difficulty to navigate the eyes when reading.
I've put more contrast to it 