### PR TITLE
feat(lxd): lxc.storage.volume package

### DIFF
--- a/packages/lxd/src/register.coffee
+++ b/packages/lxd/src/register.coffee
@@ -42,6 +42,12 @@ module.exports =
     storage:
       '': '@nikitajs/lxd/src/storage'
       delete: '@nikitajs/lxd/src/storage/delete'
+      volume:
+        '': '@nikitajs/lxd/src/storage/volume'
+        delete: '@nikitajs/lxd/src/storage/volume/delete' 
+        list: '@nikitajs/lxd/src/storage/volume/list' 
+        get: '@nikitajs/lxd/src/storage/volume/get'
+        attach: '@nikitajs/lxd/src/storage/volume/attach'
 (->
   try
     await registry.register module.exports

--- a/packages/lxd/src/storage/volume/attach.coffee.md
+++ b/packages/lxd/src/storage/volume/attach.coffee.md
@@ -1,0 +1,106 @@
+
+# `nikita.lxc.storage.volume.attach`
+
+Attach a storage volume in the selected pool to an instance of LXD.
+
+## Output parameters
+
+* `$status`
+  True if the volume was attached.
+
+## Example
+
+```js
+const {$status} = await @lxc.storage.volume.attach({
+  pool = 'default',
+  name = 'test',
+  container = 'c1',
+  device = 'test'
+})
+console.info(`The volume was deleted: ${$status}`)
+```
+
+## Schema definitions
+
+    definitions =
+      config:
+        type: 'object'
+        properties:
+          'pool':
+            type: 'string'
+            description: 'Name of the storage pool containing the volume to attach.'
+          'name':
+            type: 'string'
+            description: 'Name of the storage volume to attach.'
+          'device':
+            type: 'string'
+            description: 'Name of the device as listed in the instance.'
+          'type':
+            enum: ["custom"]
+            default: "custom"
+            description: '''
+            Type of the storage volume to attach.
+            '''
+          'container':
+            $ref: 'module://@nikitajs/lxd/src/init#/definitions/config/properties/container'
+            description: '''
+            Name of the container to attach the volume to.
+            '''
+          'path':
+            type: 'string'
+            description: '''
+            Path to mount the volume in the instance.
+            '''
+        required: ['pool', 'name', 'container', 'device']
+
+## Handler
+
+    handler = ({config}) ->
+
+      # note, getting the volume to make sure it exists
+      {$status, data} = await @lxc.storage.volume.get
+        pool: config.pool
+        name: config.name
+        type: config.type
+      if not $status
+        throw new Error('Missing requirement: Volume does not exist.')
+      volume = data
+
+      # note, getting the container to make sure it exists
+      {$status, data} = await @lxc.query
+        path: "/1.0/instances/#{config.container}"
+      if not $status
+        throw new Error('Missing requirement: Container does not exist.')
+      container = data
+
+      switch container.type
+        when 'virtual-machine' 
+          if volume.content_type == "filesystem" then throw new Error("Type: #{container.type} can only mount block type volumes.")
+        when 'container' 
+          if volume.content_type == "block" then throw new Error("Type: #{container.type} can only mount filesystem type volumes.")
+      if volume.content_type == "filesystem" and not config.path? then throw new Error("Missing requirement: Path is required for filesystem type volumes.")
+      parameters = JSON.stringify {
+        devices:
+          "#{config.device}":
+            pool: config.pool
+            source: config.name
+            type: "disk"
+            path: if config.path? then config.path else null
+      }
+
+      {$status} = await @lxc.query
+        path: "/1.0/instances/#{config.container}"
+        request: 'PATCH'
+        data: parameters
+        wait: true
+        format: "string"
+        code: [0, 42]
+      $status: $status
+      
+## Exports
+
+    module.exports =
+      handler: handler
+      metadata:
+        definitions: definitions
+        shy: true

--- a/packages/lxd/src/storage/volume/delete.coffee.md
+++ b/packages/lxd/src/storage/volume/delete.coffee.md
@@ -1,0 +1,57 @@
+
+# `nikita.lxc.storage.volume.delete`
+
+Delete a storage volume in the selected pool.
+
+## Output parameters
+
+* `$status`
+  True if the volume was deleted.
+
+## Example
+
+```js
+const {$status} = await @lxc.storage.volume.delete({
+  pool = 'default',
+  name = 'test',
+})
+console.info(`The volume was deleted: ${$status}`)
+```
+
+## Schema definitions
+
+    definitions =
+      config:
+        type: 'object'
+        properties:
+          'pool':
+            type: 'string'
+            description: 'Name of the storage pool containing the volume to delete.'
+          'name':
+            type: 'string'
+            description: 'Name of the storage volume to delete.'
+          'type':
+            enum: ["custom"]
+            default: "custom"
+            description: '''
+            Type of the storage volume to delete.
+            '''
+        required: ['pool', 'name', 'type']
+
+## Handler
+
+    handler = ({config}) ->
+      {$status} = await @lxc.query
+        path: "/1.0/storage-pools/#{config.pool}/volumes/#{config.type}/#{config.name}"
+        request: "DELETE"
+        format: 'string'
+        code: [0, 42]
+      $status: $status
+      
+## Exports
+
+    module.exports =
+      handler: handler
+      metadata:
+        definitions: definitions
+        shy: true

--- a/packages/lxd/src/storage/volume/get.coffee.md
+++ b/packages/lxd/src/storage/volume/get.coffee.md
@@ -1,0 +1,58 @@
+
+# `nikita.lxc.storage.volume.get`
+
+Get a storage volume in the selected pool.
+
+## Output parameters
+
+* `$status`
+  True if the volume was obtained.
+* `data`
+  The data returned by the API call.
+
+## Example
+
+```js
+const {data} = await @lxc.storage.volume.get({
+  pool = 'default',
+  name = 'test',
+})
+console.info(`The volume informations are: ${data}`)
+```
+
+## Schema definitions
+
+    definitions =
+      config:
+        type: 'object'
+        properties:
+          'pool':
+            type: 'string'
+            description: 'Name of the storage pool containing the volume to get.'
+          'name':
+            type: 'string'
+            description: 'Name of the storage volume to get.'
+          'type':
+            enum: ["custom"]
+            default: "custom"
+            description: '''
+            Type of storage volume to get.
+            '''
+        required: ['pool', 'name', 'type']
+
+## Handler
+
+    handler = ({config}) ->
+      {$status, data} = await @lxc.query
+        path: "/1.0/storage-pools/#{config.pool}/volumes/#{config.type}/#{config.name}"
+        code: [0, 42]
+      $status: $status
+      data: data
+      
+## Exports
+
+    module.exports =
+      handler: handler
+      metadata:
+        definitions: definitions
+        shy: true

--- a/packages/lxd/src/storage/volume/index.coffee.md
+++ b/packages/lxd/src/storage/volume/index.coffee.md
@@ -1,0 +1,87 @@
+
+# `nikita.lxc.storage.volume`
+
+Create a new storage volume in the selected pool.
+
+## Output parameters
+
+* `$status`
+  True if the volume was created.
+
+## Example
+
+```js
+const {$status} = await @lxc.storage({
+  pool = 'default',
+  name = 'test',
+})
+console.info(`The pool creation was correctly made: ${$status}`)
+```
+
+## Schema definitions
+          
+    definitions =
+      config:
+        type: 'object'
+        properties:
+          'pool':
+            type: 'string'
+            description: '''
+            Name of the storage pool to create the volume in.
+            '''
+          'name':
+            type: 'string'
+            description: '''
+            Name of the storage volume to create.
+            '''
+          'type':
+            enum: ["custom"]
+            default: "custom"
+            description: '''
+            Type of the storage volume to create.
+            '''
+          'properties':
+            type: 'object',
+            patternProperties: '': type: ['string', 'boolean', 'number']
+            description: '''
+            Configuration to use to configure this storage volume. 
+            '''
+          'content':
+            enum: ["filesystem", "block"]
+            default: "filesystem"
+            description: '''
+            Type of content to create in the storage volume.
+            Filesystem is for containers and block is for virtual machines.
+            '''
+          'description':
+            type: 'string'
+            description: '''
+            Description of the storage volume.
+            '''
+        required: ['name', 'pool', 'type']
+
+## Handler
+
+    handler = ({config}) ->
+      parameters = JSON.stringify {
+        name: config.name,
+        config: if config.properties? then config.properties else {},
+        content_type: if config.content? then config.content else null,
+        description: if config.description? then config.description else null,
+      }
+      {$status} = await @lxc.query
+        path: "/1.0/storage-pools/#{config.pool}/volumes/#{config.type}"
+        request: "POST"
+        data: parameters
+        format: 'string'
+        code: [0, 42]
+      $status: $status
+      
+
+## Exports
+
+    module.exports =
+      handler: handler
+      metadata:
+        definitions: definitions
+        shy: true

--- a/packages/lxd/src/storage/volume/list.coffee.md
+++ b/packages/lxd/src/storage/volume/list.coffee.md
@@ -1,0 +1,56 @@
+
+# `nikita.lxc.storage.volume.list`
+
+Show the list of volumes in a storage pool.
+
+## Output parameters
+
+* `$status`
+  True if the list was issued properly.
+* `list`
+  List of volumes in the pool.
+
+## Example
+
+```js
+const {list} = await @lxc.storage.volume.list({
+  pool = 'default'
+})
+console.info(`The pool contains the following volumes: ${list}`)
+```
+
+## Schema definitions
+
+    definitions =
+      config:
+        type: 'object'
+        properties:
+          'pool':
+            type: 'string'
+            description: '''
+            Name of the storage pool containing the volumes you want to list.
+            '''
+          'type':
+            enum: ["custom"]
+            default: "custom"
+            description: '''
+            Type of storage volumes to list.
+            ''' 
+        required: ['pool']
+
+## Handler
+
+    handler = ({config}) ->
+      {$status, data} = await @lxc.query
+        path: "/1.0/storage-pools/#{config.pool}/volumes/#{config.type}"
+        code: [0, 42]
+      $status: $status
+      list: (i.split('/').pop() for i in data)
+
+## Exports
+
+    module.exports =
+      handler: handler
+      metadata:
+        definitions: definitions
+        shy: true

--- a/packages/lxd/test/storage/volume/attach.coffee
+++ b/packages/lxd/test/storage/volume/attach.coffee
@@ -1,0 +1,257 @@
+nikita = require '@nikitajs/core/lib'
+{config, images, tags} = require '../../test'
+they = require('mocha-they')(config)
+
+return unless tags.lxd
+
+describe 'lxc.storage.volume.attach', ->
+
+  describe 'attach', ->
+
+    they 'should attach a volume', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.delete
+            container: 'nikita-container-attach-1'
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-attach-1'
+            name: 'nikita-volume-attach-1'
+          await @lxc.storage.delete
+            name: 'nikita-storage-attach-1'
+        await @clean()
+        # Create storage and volume
+        await @lxc.storage
+          name: 'nikita-storage-attach-1'
+          driver: "zfs"
+        await @lxc.storage.volume
+          name: 'nikita-volume-attach-1'
+          pool: 'nikita-storage-attach-1' 
+        # Create instance 
+        await @lxc.init
+          image: "images:#{images.alpine}"
+          container: 'nikita-container-attach-1'
+        # Attach volume to instance
+        {$status} = await @lxc.storage.volume.attach
+          pool: 'nikita-storage-attach-1'
+          name: 'nikita-volume-attach-1'
+          container: 'nikita-container-attach-1'
+          device: 'osd'
+          path: '/osd/'
+        $status.should.be.eql true
+        # Check if volume is attached
+        {$status, data} = await @lxc.query
+          path: '/1.0/instances/nikita-container-attach-1'
+        $status.should.be.eql true
+        data.devices.should.containEql {'osd': {type: 'disk', source: 'nikita-volume-attach-1', pool: 'nikita-storage-attach-1', path: '/osd/'}}
+        await @clean()
+
+    return unless tags.lxd_vm
+    
+    they 'should attach a block volume on a vm', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.delete
+            container: 'nikita-container-attach-2'
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-attach-2'
+            name: 'nikita-volume-attach-2'
+          await @lxc.storage.delete
+            name: 'nikita-storage-attach-2'
+        await @clean()
+        # Create storage and volume
+        await @lxc.storage
+          name: 'nikita-storage-attach-2'
+          driver: "zfs"
+        await @lxc.storage.volume
+          name: 'nikita-volume-attach-2'
+          pool: 'nikita-storage-attach-2' 
+          content: 'block'
+        # Create instance 
+        await @lxc.init
+          image: "images:#{images.alpine}"
+          container: 'nikita-container-attach-2'
+          vm:true
+        # Attach volume to instance
+        {$status} = await @lxc.storage.volume.attach
+          pool: 'nikita-storage-attach-2'
+          name: 'nikita-volume-attach-2'
+          container: 'nikita-container-attach-2'
+          device: 'osd'
+        $status.should.be.eql true
+        # Check if volume is attached
+        {$status, data} = await @lxc.query
+          path: '/1.0/instances/nikita-container-attach-2'
+        $status.should.be.eql true
+        data.devices.should.containEql {'osd': {type: 'disk', source: 'nikita-volume-attach-2', pool: 'nikita-storage-attach-2'}}
+        await @clean()
+
+  describe 'rejection', ->
+
+    they "did not specify the path with filesystem", ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.delete
+            container: 'nikita-container-attach-1'
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-attach-1'
+            name: 'nikita-volume-attach-1'
+          await @lxc.storage.delete
+            name: 'nikita-storage-attach-1'
+        await @clean()
+        # Create storage and volume
+        await @lxc.storage
+          name: 'nikita-storage-attach-1'
+          driver: "zfs"
+        await @lxc.storage.volume
+          name: 'nikita-volume-attach-1'
+          pool: 'nikita-storage-attach-1' 
+        # Create instance 
+        await @lxc.init
+          image: "images:#{images.alpine}"
+          container: 'nikita-container-attach-1'
+        # Attach volume to instance
+        await @lxc.storage.volume.attach
+          pool: 'nikita-storage-attach-1'
+          name: 'nikita-volume-attach-1'
+          container: 'nikita-container-attach-1'
+          device: 'osd'
+        .should.be.rejectedWith /^Missing requirement: Path is required for filesystem type volumes./
+        await @clean()
+
+    return unless tags.lxd_vm
+
+    they 'should attach a filesystem to a vm', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.delete
+            container: 'nikita-container-attach-2'
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-attach-2'
+            name: 'nikita-volume-attach-2'
+          await @lxc.storage.delete
+            name: 'nikita-storage-attach-2'
+        await @clean()
+        # Create storage and volume
+        await @lxc.storage
+          name: 'nikita-storage-attach-2'
+          driver: "zfs"
+        await @lxc.storage.volume
+          name: 'nikita-volume-attach-2'
+          pool: 'nikita-storage-attach-2' 
+        # Create instance 
+        await @lxc.init
+          image: "images:#{images.alpine}"
+          container: 'nikita-container-attach-2'
+          vm: true
+        # Attach volume to instance
+        await @lxc.storage.volume.attach
+          pool: 'nikita-storage-attach-2'
+          name: 'nikita-volume-attach-2'
+          container: 'nikita-container-attach-2'
+          device: 'osd'
+          path: '/osd/'
+        .should.be.rejectedWith /^Type: virtual-machine can only mount block type volumes./
+        await @clean()
+
+    they 'should attach a block volume to a container', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.delete
+            container: 'nikita-container-attach-3'
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-attach-3'
+            name: 'nikita-volume-attach-3'
+          await @lxc.storage.delete
+            name: 'nikita-storage-attach-3'
+        await @clean()
+        # Create storage and volume
+        await @lxc.storage
+          name: 'nikita-storage-attach-3'
+          driver: "zfs"
+        await @lxc.storage.volume
+          name: 'nikita-volume-attach-3'
+          pool: 'nikita-storage-attach-3'
+          content: 'block'
+        # Create instance 
+        await @lxc.init
+          image: "images:#{images.alpine}"
+          container: 'nikita-container-attach-3'
+        # Attach volume to instance
+        await @lxc.storage.volume.attach
+          pool: 'nikita-storage-attach-3'
+          name: 'nikita-volume-attach-3'
+          container: 'nikita-container-attach-3'
+          device: 'osd'
+          path: '/osd/'
+        .should.be.rejectedWith /^Type: container can only mount filesystem type volumes./
+        await @clean()
+
+    they 'should forget the volume', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.delete
+            container: 'nikita-container-attach-4'
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-attach-4'
+            name: 'nikita-volume-attach-4'
+          await @lxc.storage.delete
+            name: 'nikita-storage-attach-4'
+        await @clean()
+        # Create storage and volume
+        await @lxc.storage
+          name: 'nikita-storage-attach-4'
+          driver: "zfs"
+        await @lxc.init
+          image: "images:#{images.alpine}"
+          container: 'nikita-container-attach-4'
+        # Attach volume to instance
+        await @lxc.storage.volume.attach
+          pool: 'nikita-storage-attach-4'
+          name: 'nikita-volume-attach-4'
+          container: 'nikita-container-attach-4'
+          device: 'osd'
+          path: '/osd/'
+        .should.be.rejectedWith /^Missing requirement: Volume does not exist./
+        await @clean()
+
+    they 'should forget the container', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.delete
+            container: 'nikita-container-attach-5'
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-attach-5'
+            name: 'nikita-volume-attach-5'
+          await @lxc.storage.delete
+            name: 'nikita-storage-attach-5'
+        await @clean()
+        # Create storage and volume
+        await @lxc.storage
+          name: 'nikita-storage-attach-5'
+          driver: "zfs"
+        await @lxc.storage.volume
+          name: 'nikita-volume-attach-5'
+          pool: 'nikita-storage-attach-5'
+        # Attach volume to instance
+        await @lxc.storage.volume.attach
+          pool: 'nikita-storage-attach-5'
+          name: 'nikita-volume-attach-5'
+          container: 'nikita-container-attach-5'
+          device: 'osd'
+          path: '/osd/'
+        .should.be.rejectedWith /^Missing requirement: Container does not exist./
+        await @clean()

--- a/packages/lxd/test/storage/volume/delete.coffee
+++ b/packages/lxd/test/storage/volume/delete.coffee
@@ -1,0 +1,44 @@
+nikita = require '@nikitajs/core/lib'
+{config, tags} = require '../../test'
+they = require('mocha-they')(config)
+
+return unless tags.lxd
+
+describe 'lxc.storage.volume.delete', ->
+
+  they 'delete a volume', ({ssh}) ->
+    nikita
+      $ssh: ssh
+    , ->
+      await @lxc.storage
+        name: 'nikita-storage-delete-1'
+        driver: "zfs"
+      await @lxc.storage.volume
+        name: 'nikita-volume-delete-1'
+        pool: 'nikita-storage-delete-1'
+      {$status} = await @lxc.storage.volume.delete 
+        pool: 'nikita-storage-delete-1'
+        name: 'nikita-volume-delete-1'
+      await @lxc.storage.delete
+        name: 'nikita-storage-delete-1'
+      $status.should.be.eql true
+  
+  they 'double delete a volume', ({ssh}) ->
+    nikita
+      $ssh: ssh
+    , ->
+      await @lxc.storage
+        name: 'nikita-storage-delete-2'
+        driver: "zfs"
+      await @lxc.storage.volume
+        name: 'nikita-volume-delete-2'
+        pool: 'nikita-storage-delete-2'
+      await @lxc.storage.volume.delete 
+        pool: 'nikita-storage-delete-2'
+        name: 'nikita-volume-delete-2'
+      {$status} = await @lxc.storage.volume.delete 
+        pool: 'nikita-storage-delete-2'
+        name: 'nikita-volume-delete-2'
+      await @lxc.storage.delete
+        name: 'nikita-storage-delete-2'
+      $status.should.be.eql false

--- a/packages/lxd/test/storage/volume/get.coffee
+++ b/packages/lxd/test/storage/volume/get.coffee
@@ -1,0 +1,51 @@
+nikita = require '@nikitajs/core/lib'
+{config, tags} = require '../../test'
+they = require('mocha-they')(config)
+
+return unless tags.lxd
+
+describe 'lxc.storage.volume.get', ->
+
+  they 'get a volume', ({ssh}) ->
+    nikita
+      $ssh: ssh
+    , ({registry}) ->
+      registry.register 'clean', ->
+        await @lxc.storage.volume.delete 
+          pool: 'nikita-storage-get-1'
+          name: 'nikita-volume-get-1'
+        await @lxc.storage.delete
+          name: 'nikita-storage-get-1'
+      await @clean()
+      await @lxc.storage
+        name: 'nikita-storage-get-1'
+        driver: "zfs"
+      await @lxc.storage.volume
+        name: 'nikita-volume-get-1'
+        pool: 'nikita-storage-get-1'
+      {$status, data} = await @lxc.storage.volume.get
+        pool: 'nikita-storage-get-1'
+        name: 'nikita-volume-get-1'
+      $status.should.be.eql true
+      data.name.should.be.eql 'nikita-volume-get-1'
+      await @clean()
+  
+  they "get a volume that doesn't exist", ({ssh}) ->
+    nikita
+      $ssh: ssh
+    , ({registry}) ->
+      registry.register 'clean', ->
+        await @lxc.storage.volume.delete 
+          pool: 'nikita-storage-get-2'
+          name: 'nikita-volume-get-2'
+        await @lxc.storage.delete
+          name: 'nikita-storage-get-2'
+      await @clean()
+      await @lxc.storage
+        name: 'nikita-storage-get-2'
+        driver: "zfs"
+      {$status, data} = await @lxc.storage.volume.get
+        pool: 'nikita-storage-get-2'
+        name: 'nikita-volume-get-2'
+      $status.should.be.eql false
+      await @clean()

--- a/packages/lxd/test/storage/volume/index.coffee
+++ b/packages/lxd/test/storage/volume/index.coffee
@@ -1,0 +1,143 @@
+nikita = require '@nikitajs/core/lib'
+{config, tags} = require '../../test'
+they = require('mocha-they')(config)
+
+return unless tags.lxd
+
+describe 'lxc.storage.volume', ->
+
+  describe 'volume creation', ->
+
+    they 'create a volume', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-create-1'
+            name: 'nikita-volume-create-1'
+          await @lxc.storage.delete
+            name: 'nikita-storage-create-1'
+        await @clean()
+        await @lxc.storage
+          name: 'nikita-storage-create-1'
+          driver: "zfs"
+        {$status} = await @lxc.storage.volume
+          name: 'nikita-volume-create-1'
+          pool: 'nikita-storage-create-1'
+        $status.should.be.eql true
+        await @clean()
+    
+    they 'create a volume in a non-existing pool', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-create-2'
+            name: 'nikita-volume-create-2'
+          await @lxc.storage.delete
+            name: 'nikita-storage-create-2'
+        await @clean()
+        {$status} = await @lxc.storage.volume
+          name: 'nikita-volume-create-2'
+          pool: 'nikita-storage-create-2'
+        $status.should.be.eql false
+        await @clean()
+    
+    they 'create two times the same volume', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-create-3'
+            name: 'nikita-volume-create-3'
+          await @lxc.storage.delete
+            name: 'nikita-storage-create-3'
+        await @clean()
+        await @lxc.storage
+          name: 'nikita-storage-create-3'
+          driver: "zfs"
+        {$status} = await @lxc.storage.volume
+          name: 'nikita-volume-create-3'
+          pool: 'nikita-storage-create-3'
+        $status.should.be.eql true
+        {$status} = await @lxc.storage.volume
+          name: 'nikita-volume-create-3'
+          pool: 'nikita-storage-create-3'
+        $status.should.be.eql false
+        await @clean()
+
+  describe 'volume configuration', ->
+
+    they 'create a volume with config', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-config-1'
+            name: 'nikita-volume-config-1'
+          await @lxc.storage.delete
+            name: 'nikita-storage-config-1'
+        await @clean()
+        await @lxc.storage
+          name: 'nikita-storage-config-1'
+          driver: "zfs"
+        await @lxc.storage.volume
+          name: 'nikita-volume-config-1'
+          pool: 'nikita-storage-config-1'
+          properties:
+            size: '10GB'
+        {data} = await @lxc.storage.volume.get
+          pool: 'nikita-storage-config-1'
+          name: 'nikita-volume-config-1'
+        data.config.size.should.be.eql '10GB'
+        await @clean()
+
+    they 'create a volume with wrong config', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-config-2'
+            name: 'nikita-volume-config-2'
+          await @lxc.storage.delete
+            name: 'nikita-storage-config-2'
+        await @clean()
+        await @lxc.storage
+          name: 'nikita-storage-config-2'
+          driver: "zfs"
+        {$status} = await @lxc.storage.volume
+          name: 'nikita-volume-config-2'
+          pool: 'nikita-storage-config-2'
+          properties:
+            size: '10gb'
+        $status.should.be.eql false
+        await @clean()
+
+    they 'create a volume filesystem', ({ssh}) ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        registry.register 'clean', ->
+          await @lxc.storage.volume.delete 
+            pool: 'nikita-storage-config-3'
+            name: 'nikita-volume-config-3'
+          await @lxc.storage.delete
+            name: 'nikita-storage-config-3'
+        await @clean()
+        await @lxc.storage
+          name: 'nikita-storage-config-3'
+          driver: "zfs"
+        await @lxc.storage.volume
+          name: 'nikita-volume-config-3'
+          pool: 'nikita-storage-config-3'
+          content: 'block'
+        {data} = await @lxc.storage.volume.get
+          pool: 'nikita-storage-config-3'
+          name: 'nikita-volume-config-3'
+        data.content_type.should.be.eql 'block'
+        await @clean()  

--- a/packages/lxd/test/storage/volume/list.coffee
+++ b/packages/lxd/test/storage/volume/list.coffee
@@ -1,0 +1,38 @@
+nikita = require '@nikitajs/core/lib'
+{config, tags} = require '../../test'
+they = require('mocha-they')(config)
+
+return unless tags.lxd
+
+describe 'lxc.storage.volume.list', ->
+
+  they 'list all volumes in a pool', ({ssh}) ->
+    nikita
+      $ssh: ssh
+    , ({registry}) ->
+      registry.register 'clean', ->
+        await @lxc.storage.volume.delete 
+          pool: 'nikita-storage-list-1'
+          name: 'nikita-volume-list-1'
+        await @lxc.storage.delete
+          name: 'nikita-storage-list-1'
+      await @clean()
+      await @lxc.storage
+        name: 'nikita-storage-list-1'
+        driver: "zfs"
+      await @lxc.storage.volume
+        name: 'nikita-volume-list-1'
+        pool: 'nikita-storage-list-1'
+      {$status, list} = await @lxc.storage.volume.list
+        pool: 'nikita-storage-list-1'
+      $status.should.be.eql true 
+      list.should.containEql 'nikita-volume-list-1'
+      await @clean()
+
+  they 'list all volumes in an non-existing pool', ({ssh}) ->
+    nikita
+      $ssh: ssh
+    , ->
+      {$status} = await @lxc.storage.volume.list
+        pool: 'nikita-storage-list-2'
+      $status.should.be.eql false


### PR DESCRIPTION
# lxc.storage.volume package

## Description

This is a package for `lxc storage volume` using `lxc.query` designed to:

- Create volumes (see [index.coffee.md](./packages/lxd/src/storage/volume/index.coffee.md))
- Delete volumes (see [delete.coffee.md](./packages/lxd/src/storage/volume/delete.coffee.md))
- Get volumes (see [get.coffee.md](./packages/lxd/src/storage/volume/get.coffee.md))
- List volumes (see [list.coffee.md](./packages/lxd/src/storage/volume/list.coffee.md))
- Attach volumes to containers (see [attach.coffee.md](./packages/lxd/src/storage/volume/index.coffee.md))

**Warning**: This pull request is building upon the following PR: https://github.com/adaltas/node-nikita/pull/388.

## Motivations

We need to be able to create OSDs for Rook-Ceph. This can be achieved by creating a new volume, and attaching it to a worker node of a Kubernetes cluster. We must know if the volume exist (get), be able to create one (create) and delete one (delete), as well as listing existing volumes (list). Finally, we can attach our volume to the container.

## TODO

If deemed useful, the `detach` functionality may come in handy. We can talk about it.

