### PR TITLE
feat(lxd): lxc.wait.ready package

### DIFF
--- a/packages/lxd/src/wait/ready.coffee.md
+++ b/packages/lxd/src/wait/ready.coffee.md
@@ -1,0 +1,77 @@
+
+# `nikita.lxc.wait.ready`
+
+Wait for a container to be ready to use.
+
+## Example
+
+```js
+const {$status} = await nikita.lxc.wait.ready({
+  container: "myubuntu"
+})
+console.info(`Container is ready: ${$status}`)
+```
+
+## Schema definitions
+
+    definitions =
+      config:
+        type: 'object'
+        properties:
+          'container':
+            $ref: 'module://@nikitajs/lxd/src/init#/definitions/config/properties/container'
+          'nat':
+            type: 'boolean'
+            default: false
+            description: """
+            If true, will wait for internet to be connected
+            """
+        required: ['container']
+
+## Handler
+
+    handler = ({config}) ->
+      {$status} = await @call
+        $retry: 100
+        $sleep: 1000
+        () ->
+          {config:{processes}} = await @lxc.state
+            $header: "Checking if instance is ready"
+            container: config.container
+          # Processes are at -1 when they aren't ready
+          if processes < 0
+            throw Error "Reschedule: Instance not booted"
+          # Sometimes processes alone aren't enough, so we test if we can get the container
+          {$status} = await @lxc.exec
+            $header: "Trying to execute a command"
+            container: config.container
+            command:"""
+            if ( command -v systemctl || command -v rc-service ); then
+              exit 0
+            else 
+              exit 42
+            fi
+            """
+            code: [0, 42]
+          if $status is false
+            throw Error "Reschedule: Instance not ready to execute commands"
+          # Checking if internet is working and ready for us to use
+          if config.nat is true
+            {$status} = await @lxc.exec
+              $header: "Trying to connect to internet"
+              container: config.container
+              command:"""
+              ping -c 2 8.8.8.8 || exit 42
+              """
+              code: [0, 42]
+            if $status is false
+              throw Error "Reschedule: Internet not ready"
+      $status: $status
+
+## Exports
+
+    module.exports =
+      handler: handler
+      metadata:
+        argument_to_config: 'container'
+        definitions: definitions

--- a/packages/lxd/test/wait/ready.coffee
+++ b/packages/lxd/test/wait/ready.coffee
@@ -1,0 +1,123 @@
+
+nikita = require '@nikitajs/core/lib'
+{config, images, tags} = require '../../test'
+they = require('mocha-they')(config)
+
+
+describe 'lxc.wait.ready', ->
+
+  describe 'For containers', ->
+
+    return unless tags.lxd
+
+    they 'wait for the container to be ready', ({ssh})  ->
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        await registry.register 'clean', ->
+          await @lxc.delete 
+            container: 'nikita-wait-1'
+            force: true
+        await registry.register 'test', ->
+          await @lxc.init
+            image: "images:#{images.alpine}"
+            container: 'nikita-wait-1'
+            start: true
+          {$status} = await @lxc.wait.ready 'nikita-wait-1'
+          $status.should.be.true()
+        try 
+          await @clean()
+          await @test()
+        finally
+          await @clean()
+  
+  describe 'For virtual machines', ->
+
+    return unless tags.lxd_vm
+
+    they 'wait for the virtual machine to be ready', ({ssh})  ->
+      @timeout -1
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        await registry.register 'clean', ->
+          await @lxc.delete 
+            container: 'nikita-wait-2'
+            force: true
+        await registry.register 'test', ->
+          await @lxc.init
+            image: "images:centos/7"
+            container: 'nikita-wait-2'
+            vm: true
+            properties:
+              'security.secureboot': false
+            start: true
+          {$status} = await @lxc.wait.ready 'nikita-wait-2'
+          $status.should.be.true()
+        try 
+          await @clean()
+          await @test()
+        finally
+          await @clean()
+    
+    they 'try to execute a command after booting', ({ssh})  ->
+      @timeout -1
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        await registry.register 'clean', ->
+          await @lxc.delete 
+            container: 'nikita-wait-3'
+            force: true
+        await registry.register 'test', ->
+          await @lxc.init
+            image: "images:centos/7"
+            container: 'nikita-wait-3'
+            vm: true
+            properties:
+              'security.secureboot': false
+            start: true
+          await @lxc.wait.ready 'nikita-wait-3'
+          {$status} = await @lxc.exec 
+            container: 'nikita-wait-3'
+            command: '''
+            echo "hello"
+            '''
+          $status.should.be.true()
+        try 
+          await @clean()
+          await @test()
+        finally
+          await @clean()      
+
+    return unless tags.lxd_vm
+    
+    they 'try to execute a command before booting', ({ssh})  ->
+      @timeout -1
+      nikita
+        $ssh: ssh
+      , ({registry}) ->
+        await registry.register 'clean', ->
+          await @lxc.delete 
+            container: 'nikita-wait-4'
+            force: true
+        await registry.register 'test', ->
+          await @lxc.init
+            image: "images:centos/7"
+            container: 'nikita-wait-4'
+            vm: true
+            properties:
+              'security.secureboot': false
+            start: true
+          {$status} = await @lxc.exec 
+            container: 'nikita-wait-4'
+            command: '''
+            echo "hello"
+            '''
+        try 
+          await @clean()
+          await @test()
+        catch err
+          err.$status.should.be.false()
+        finally
+          await @clean()      


### PR DESCRIPTION
# lxc.wait.ready

## Description

`Running` instances doesn't mean that they are ready for commands to be executed with `lxc.exec`, or that the internet connection is ready.

`lxc.wait.ready` checks, chronologically:

- If an instance has booted
- If an instance allows commands to be executed
- (`nat` flag) If an instance is ready to use internet 