### PR TITLE
refactor(lxd): lxc.network.delete using lxc.query

### DIFF
--- a/packages/lxd/src/network/delete.coffee.md
+++ b/packages/lxd/src/network/delete.coffee.md
@@ -26,26 +26,17 @@ console.info(`Network was deleted: ${$status}`)
           'network':
             type: 'string'
             description: '''
-            The network name to delete.
+            Name of the network to delete.
             '''
         required: ['network']
 
 ## Handler
 
     handler = ({config}) ->
-      #Execute
-      await @execute
-        command: """
-        lxc network list --format csv | grep #{config.network} || exit 42
-        #{[
-          'lxc'
-          'network'
-          'delete'
-           config.network
-        ].join ' '}
-        """
-        code: [0, 42]
-
+      await @lxc.query
+        path: "/1.0/networks/#{config.network}"
+        request: 'DELETE'
+        format: 'string'
 ## Exports
 
     module.exports =

--- a/packages/lxd/test/network/delete.coffee
+++ b/packages/lxd/test/network/delete.coffee
@@ -16,6 +16,8 @@ describe 'lxc.network.delete', ->
       {$status} = await @lxc.network.delete
         network: "nkt-delete-1"
       $status.should.be.true()
+      {list} = await @lxc.network.list()
+      list.should.not.containEql 'nkt-delete-1'
           
   they 'Network already deleted', ({ssh}) ->
     nikita


### PR DESCRIPTION
# Refactor: lxc.network.delete

## Description

Usage of `lxc.query` for network deletion, and improvement of previous test.