### PR TITLE
fix(lxd): lxc.network missing await in tests

### DIFF
--- a/packages/lxd/test/network/index.coffee
+++ b/packages/lxd/test/network/index.coffee
@@ -33,7 +33,7 @@ describe 'lxc.network.create', ->
       $ssh: ssh
     , ({registry}) ->
       await registry.register 'clean', ->
-        @lxc.network.delete
+        await @lxc.network.delete
           network: "nkt-network-2"
       try
         await @clean()
@@ -48,7 +48,7 @@ describe 'lxc.network.create', ->
       $ssh: ssh
     , ({registry}) ->
       await registry.register 'clean', ->
-        @lxc.network.delete
+        await @lxc.network.delete
           network: "nkt-network-3"
       try
         {$status} = await @lxc.network
@@ -66,7 +66,7 @@ describe 'lxc.network.create', ->
       $ssh: ssh
     , ({registry}) ->
       await registry.register 'clean', ->
-        @lxc.network.delete
+        await @lxc.network.delete
           network: "nkt-network-4"
       try
         await @lxc.network
@@ -82,7 +82,7 @@ describe 'lxc.network.create', ->
       $ssh: ssh
     , ({registry}) ->
       await registry.register 'clean', ->
-        @lxc.network.delete
+        await @lxc.network.delete
           network: "nkt-network-5"
       try
         await @lxc.network
@@ -101,7 +101,7 @@ describe 'lxc.network.create', ->
       $ssh: ssh
     , ({registry}) ->
       await registry.register 'clean', ->
-        @lxc.network.delete
+        await @lxc.network.delete
           network: "nkt-network-6"
       try
         {$status} = await @lxc.network
@@ -130,7 +130,7 @@ describe 'lxc.network.create', ->
       $ssh: ssh
     , ({registry}) ->
       await registry.register 'clean', ->
-        @lxc.network.delete
+        await @lxc.network.delete
           network: "nkt-network-7"
       try
         await @lxc.network

--- a/packages/lxd/test/network/list.coffee
+++ b/packages/lxd/test/network/list.coffee
@@ -12,15 +12,21 @@ describe 'lxc.network.list', ->
       $ssh: ssh
     , ({registry}) ->
       registry.register 'clean', ->
-        @lxc.network.delete
+        await @lxc.network.delete
           network: 'nkttestnetlist'
-      await @clean()
-      await @lxc.network
-        network: 'nkttestnetlist'
-        properties:
-          'ipv4.address': '192.0.2.1/30'
-          'dns.domain': 'nikita.net.test'
-      {$status, list} = await @lxc.network.list()
-      $status.should.be.true()
-      list.should.containEql 'nkttestnetlist'
-      await @clean()
+      registry.register 'test', ->
+        await @lxc.network
+          network: 'nkttestnetlist'
+          properties:
+            'ipv4.address': '192.0.2.1/30'
+            'dns.domain': 'nikita.net.test'
+        {$status, list} = await @lxc.network.list()
+        $status.should.be.true()
+        list.should.containEql 'nkttestnetlist'
+      try 
+        await @clean()
+        await @test()
+      catch err
+        await @clean()
+      finally 
+        await @clean()


### PR DESCRIPTION
# lxc.network missing await in tests

## Description

Issue https://github.com/adaltas/node-nikita/issues/385.
Some tests were failing due to missing `await` keyword here and there.

## System

NixOs 22.05
LXD 5.0.0
NodeJs 16.14.2