### PR TITLE
feat(lxd): lxc.resources implementation

### DIFF
--- a/packages/lxd/src/register.coffee
+++ b/packages/lxd/src/register.coffee
@@ -48,6 +48,7 @@ module.exports =
         list: '@nikitajs/lxd/src/storage/volume/list' 
         get: '@nikitajs/lxd/src/storage/volume/get'
         attach: '@nikitajs/lxd/src/storage/volume/attach'
+    resources: '@nikitajs/lxd/src/resources'
 (->
   try
     await registry.register module.exports

--- a/packages/lxd/src/resources.coffee.md
+++ b/packages/lxd/src/resources.coffee.md
@@ -6,16 +6,13 @@ Show full information about the resources available to the LXD server.
 ## Output parameters
 
 * `$status` (boolean)
-* `config` (object)   
+* `config` (object)
   Information about the resources available to the LXD server.
 
 ## Example
 
 ```js
-const {config} = await nikita.lxc.resources({
-  container: 'container1',
-  device: 'disk'
-})
+const {config} = await nikita.lxc.resources()
 console.info(config)
 ```
 
@@ -24,28 +21,15 @@ console.info(config)
     definitions =
       config:
         type: 'object'
-        properties:
-          'container':
-            $ref: 'module://@nikitajs/lxd/src/init#/definitions/config/properties/container'
-          'device':
-            enum: ['none', 'nic', 'disk', 'unix-char', 'unix-block', 'usb', 'gpu', 'infiniband', 'proxy']
-            description: '''
-            Name of the device in LXD configuration, for example "eth0".
-            '''
-        required: ['container', 'device']
 
 ## Handler
 
     handler = ({config}) ->
-      {stdout} = await @execute
-        command: [
-          'lxc', 'query',
-          '/' + [
-            '1.0', 'resources'
-          ].join '/'
-        ].join ' '
-      config: JSON.parse stdout
-
+      {data, $status} = await @lxc.query
+        path: "/1.0/resources"
+      $status: $status
+      config: data
+      
 ## Exports
 
     module.exports =
@@ -55,8 +39,7 @@ console.info(config)
 
 ## Output example
 
-```
-lxc query /1.0/containers/c1/state
+```json
 {
  "cpu": {
    "usage": 800378470122

--- a/packages/lxd/test/resources.coffee
+++ b/packages/lxd/test/resources.coffee
@@ -1,0 +1,16 @@
+
+nikita = require '@nikitajs/core/lib'
+{tags, config} = require './test'
+they = require('mocha-they')(config)
+
+return unless tags.lxd
+
+describe 'lxc.resources', ->
+
+  they "check the cpu and the memory", ({ssh}) ->
+    nikita
+      $ssh: ssh
+    , ->
+      {$status, config} = await @lxc.resources()
+      $status.should.eql true
+      {cpus: config.cpu.total.toString(), memory: config.memory.total.toString()}.should.match {cpus: /^\d+$/, memory: /^\d+$/ }


### PR DESCRIPTION
# lxc.resources

## Description

Allow the user to get the information of the machine hosting `lxc`.

It was previously started but not implemented.