### PR TITLE
feat(db): fix docker healthcheck. 

### DIFF
--- a/packages/db/env/mysql/docker-compose.yml
+++ b/packages/db/env/mysql/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   nodejs:
     build: .
     container_name: nikita_db_mysql_nodejs
+    # To avoid an error in the latest versions: ERROR 2059 (HY000): Authentication plugin 'caching_sha2_password' cannot be loaded
+    command: --default-authentication-plugin=caching_sha2_password
     depends_on:
       mysql:
         condition: service_healthy

--- a/packages/db/env/mysql/docker-compose.yml
+++ b/packages/db/env/mysql/docker-compose.yml
@@ -4,10 +4,8 @@ services:
     build: .
     container_name: nikita_db_mysql_nodejs
     depends_on:
-      - mysql
-      # Not fully working for now, waiting is implemented inside entrypoint.sh
-      # mysql:
-      #   condition: service_healthy
+      mysql:
+        condition: service_healthy
     environment:
       NIKITA_TEST_MODULE: /nikita/packages/db/env/mysql/test.coffee
     image: nikita_db_mysql_nodejs
@@ -17,17 +15,14 @@ services:
       - ../../../../:/nikita
   mysql:
     container_name: nikita_db_mysql_db
-    # To avoid an error in the latest versions: ERROR 2059 (HY000): Authentication plugin 'caching_sha2_password' cannot be loaded
-    command: --default-authentication-plugin=caching_sha2_password
     environment:
       MYSQL_ROOT_PASSWORD: rootme
     expose:
       - "3306"
-    # healthcheck:
-    #   test: "bash -c 'echo > /dev/tcp/mysql/3306'"
-    #   interval: 1s
-    #   timeout: 1s
-    #   retries: 20
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "mysql"]
+      timeout: 20s
+      retries: 10
     image: mysql:latest
     # logging:
     #   driver: none

--- a/packages/db/env/mysql/entrypoint.sh
+++ b/packages/db/env/mysql/entrypoint.sh
@@ -5,7 +5,6 @@
 # command that fails is part of the command list immediately following a while
 # or until keyword"
 # set -e
-
 # Source Node.js
 . ~/.bashrc
 # Start ssh daemon

--- a/packages/db/env/mysql/entrypoint.sh
+++ b/packages/db/env/mysql/entrypoint.sh
@@ -10,12 +10,6 @@
 . ~/.bashrc
 # Start ssh daemon
 sudo /usr/sbin/sshd
-# Wait until MySQL is ready
-i=0; until echo > /dev/tcp/mysql/3306; do
-   [[ i -eq 10 ]] && >&2 echo 'Docker not yet started after 10s' && exit 1
-   ((i++))
-   sleep 1
-done
 # Test execution
 if test -t 0; then
   # We have TTY, so probably an interactive container...


### PR DESCRIPTION
While running the test db for docker mysql, it crashed on the health check, just adding the docker compose health check parameters using the best practice mysql health check methods (ping) : https://dev.mysql.com/doc/refman/8.0/en/mysqladmin.html